### PR TITLE
FIX: Progress animation resource consumption

### DIFF
--- a/dist/styles/commonStyles.scss
+++ b/dist/styles/commonStyles.scss
@@ -40,15 +40,14 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 
   @keyframes slideright {
     from {
-      margin-left: -$indefiniteMarkerWidth;
+      transform: translateX(-100%);
     }
     to {
-      margin-left: 100%;
+      transform: translateX(50%);
     }
   }
 
   .indefinite {
-    margin-left: -$indefiniteMarkerWidth;
     animation-name: slideright;
     animation-duration: 2s;
     animation-iteration-count: infinite;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@origam/styles",
   "main": "dist",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "GPL-3.0",
   "files": [
     "dist"


### PR DESCRIPTION
Progress animation used margin parameter whose change causes layout recomputation. Running another animation concurrently with the progress caused it to flick.